### PR TITLE
Fixed. could not connect to server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,11 +56,8 @@ jobs:
 
       - run: ./.circleci/bundle_install.sh
 
-      - run:
-          name: install dockerize
-          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-          environment:
-            DOCKERIZE_VERSION: v0.3.0
+      # https://circleci.com/docs/2.0/postgres-config/#using-dockerize
+      # dockerize is already installed in circleci/ruby
       - run:
           name: Wait for db
           command: dockerize -wait tcp://localhost:5432 -timeout 1m


### PR DESCRIPTION
https://circleci.com/gh/sue445/chatwork_mention_task/376

```
could not connect to server: Connection refused
	Is the server running on host "127.0.0.1" and accepting
	TCP/IP connections on port 5432?
Couldn't create database for {"adapter"=>"postgresql", "encoding"=>"unicode", "pool"=>5, "database"=>"chatwork_mention_task_test"}
rails aborted!
PG::ConnectionBad: could not connect to server: Connection refused
	Is the server running on host "127.0.0.1" and accepting
	TCP/IP connections on port 5432?
/home/circleci/app/vendor/bundle/ruby/2.5.0/gems/pg-0.21.0/lib/pg.rb:56:in `initialize'
/home/circleci/app/vendor/bundle/ruby/2.5.0/gems/pg-0.21.0/lib/pg.rb:56:in `new'
/home/circleci/app/vendor/bundle/ruby/2.5.0/gems/pg-0.21.0/lib/pg.rb:56:in `connect'
/home/circleci/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0.beta2/lib/active_record/connection_adapters/postgresql_adapter.rb:674:in `connect'
/home/circleci/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0.beta2/lib/active_record/connection_adapters/postgresql_adapter.rb:208:in `initialize'
/home/circleci/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0.beta2/lib/active_record/connection_adapters/postgresql_adapter.rb:40:in `new'
/home/circleci/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0.beta2/lib/active_record/connection_adapters/postgresql_adapter.rb:40:in `postgresql_connection'
```