### PR TITLE
Add rubocop-rails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
-require: rubocop-performance
+require:
+  - rubocop-performance
+  - rubocop-rails
 
 inherit_gem:
   onkcop:

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :development do
 
   gem "pry-byebug", group: :test
   gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,6 +283,9 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     rubocop-performance (1.4.0)
       rubocop (>= 0.71.0)
+    rubocop-rails (2.0.1)
+      rack (>= 1.1)
+      rubocop (>= 0.70.0)
     rubocop-rspec (1.33.0)
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.1)
@@ -385,6 +388,7 @@ DEPENDENCIES
   rspec-its
   rspec-rails
   rubocop-performance
+  rubocop-rails
   sassc-rails
   simplecov
   slim-rails


### PR DESCRIPTION
```
$ bundle install

Rails cops will be removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.
```