### PR TITLE
Fix heroku error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ gem "i18n-tasks"
 gem "jbuilder"
 gem "jquery-rails"
 gem "komachi_heartbeat", github: "mitaku/komachi_heartbeat", branch: "master", ref: "cd04393" # TODO: Use gemified version
+gem "net-imap"
+gem "net-pop"
 gem "net-smtp"
 gem "newrelic_rpm"
 gem "nokogiri", ">= 1.11.0.rc4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,14 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
+    net-imap (0.2.3)
+      digest
+      net-protocol
+      strscan
+    net-pop (0.1.1)
+      digest
+      net-protocol
+      timeout
     net-protocol (0.1.3)
       timeout
     net-smtp (0.3.1)
@@ -370,6 +378,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    strscan (3.0.4)
     sync (0.5.0)
     temple (0.8.2)
     term-ansicolor (1.7.1)
@@ -427,6 +436,8 @@ DEPENDENCIES
   jquery-rails
   komachi_heartbeat!
   listen
+  net-imap
+  net-pop
   net-smtp
   newrelic_rpm
   nokogiri (>= 1.11.0.rc4)


### PR DESCRIPTION
```
Jul 28 23:26:45 chatwork-mention-task app/web.1 ! Unable to load application: LoadError: cannot load such file -- net/pop
Jul 28 23:26:45 chatwork-mention-task app/web.1 bundler: failed to load command: puma (/app/vendor/bundle/ruby/3.1.0/bin/puma)
Jul 28 23:26:45 chatwork-mention-task app/web.1 /app/vendor/bundle/ruby/3.1.0/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:27:in `require': cannot load such file -- net/pop (LoadError)
Jul 28 23:26:45 chatwork-mention-task app/web.1 	from /app/vendor/bundle/ruby/3.1.0/gems/zeitwerk-2.6.0/lib/zeitwerk/kernel.rb:35:in `require'
Jul 28 23:26:45 chatwork-mention-task app/web.1 	from /app/vendor/bundle/ruby/3.1.0/gems/mail-2.7.1/lib/mail/network/retriever_methods/pop3.rb:36:in `<class:POP3>'
Jul 28 23:26:45 chatwork-mention-task app/web.1 	from /app/vendor/bundle/ruby/3.1.0/gems/mail-2.7.1/lib/mail/network/retriever_methods/pop3.rb:35:in `<module:Mail>'
Jul 28 23:26:45 chatwork-mention-task app/web.1 	from /app/vendor/bundle/ruby/3.1.0/gems/mail-2.7.1/lib/mail/network/retriever_methods/pop3.rb:4:in `<main>'
Jul 28 23:26:45 chatwork-mention-task app/web.1 	from /app/vendor/bundle/ruby/3.1.0/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
Jul 28 23:26:45 chatwork-mention-task app/web.1 	from /app/vendor/bundle/ruby/3.1.0/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:i
```